### PR TITLE
Create Production OW Build for Windows & new opk creation

### DIFF
--- a/template.json
+++ b/template.json
@@ -30,9 +30,12 @@
             ]
         },
         "scripts": {
-            "pack-overwolf": "./create-production-overwolf-build.sh",
+            "pack-overwolf": "node create-production-overwolf-build",
+            "dist-overwolf": "tar -a -c -f dist.zip -C build *",
             "start-remote-devtools": "node remote-dev-redux-devtools",
-            "build:overwolf":"npm run build && npm run pack-overwolf"
+            "build:overwolf": "npm run build && npm run pack-overwolf && npm run dist-overwolf",
+            "create-opk": "tar -a -c -f dist-opk.zip -C build/app * && node create-opk"
+            
         },
         "homepage": "."
     }

--- a/template/create-opk.js
+++ b/template/create-opk.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+console.log("Init overwolf opk packaging")
+
+const currentDir = __dirname;
+const distFile = path.join(currentDir, 'dist-opk.zip')
+const opkFile = path.join(currentDir, 'dist-opk.opk')
+
+fs.copyFileSync(distFile, opkFile)
+
+
+console.log("opk created successfully!")

--- a/template/create-production-overwolf-build.js
+++ b/template/create-production-overwolf-build.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const { existsSync, mkdirSync, renameSync } = fs;
+
+console.log("Init overwolf build")
+
+const currentDir = __dirname;
+
+const fileDir = path.join(currentDir, 'build')
+const buildDir = path.join(fileDir, 'app', 'Files');
+
+// Creating Files directory if doesn't exists
+if (!existsSync(buildDir)){
+    mkdirSync(buildDir);
+}
+
+// Moving index.html and static folder
+const index = 'index.html'
+const static = 'static'
+
+const customRename = (name) => {
+    const oldPath = path.join(fileDir, name)
+    const newPath = path.join(buildDir, name)
+    renameSync(oldPath, newPath)
+}
+
+customRename(index);
+customRename(static);
+
+console.log("Compiled successfully!");

--- a/template/create-production-overwolf-build.sh
+++ b/template/create-production-overwolf-build.sh
@@ -1,7 +1,0 @@
-echo 'Init overwolf build...'
-cd build
-cd app
-mkdir Files
-mv ../index.html Files
-mv ../static Files
-echo 'Compiled successfully!'


### PR DESCRIPTION
The `create-production-overwolf-build.sh` was pretty simple to replicate in Node.js, so that it would work also on Windows.

I also added a couple of scripts to:
1. automatically zip the build folder, as described in the readme, with `npm run dist-overwolf`. This has been tested on Windows 10, where the `tar` command is available natively, but `tar`  should also be available natively on Linux and MacOS, IIRC.
2. automatically create from the build folder an `.opk` file to install for testing purposes. It uses directly the `build/app` content to generate a `dist-opk.zip` file and converts it to `opk`.